### PR TITLE
Fix MCP server executable error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@kazuph/mcp-google-image-search",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MCP server for Google Image Search with support for both Google Custom Search API and SerpAPI",
   "main": "dist/index.js",
   "type": "module",
+  "bin": {
+    "mcp-google-image-search": "./dist/index.js"
+  },
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { searchImages, downloadImage, calculateRelevanceScore, fetchImageAsBase64, initializeApiConfig } from "./api.js";


### PR DESCRIPTION
## Summary
- Fix `npm error could not determine executable to run` by adding bin field and shebang line
- Enable proper MCP server execution via npx

## Changes
- Added `bin` field to package.json pointing to `./dist/index.js`
- Added shebang line `#!/usr/bin/env node` to src/index.ts 
- Updated version from 1.0.0 to 1.0.1

## Test Results
- ✅ Build: `npm run build` completed successfully
- ✅ Tests: All 23 tests passed (3 test suites)
- ✅ Security tests verified (command injection, path traversal, SSRF prevention)

## Problem Solved
Before: `npm error could not determine executable to run`
After: MCP server can be executed properly via npx

🤖 Generated with [Claude Code](https://claude.ai/code)