### PR TITLE
chore: cut 1.1.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kazuph/mcp-google-image-search",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kazuph/mcp-google-image-search",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kazuph/mcp-google-image-search",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MCP server for Google Image Search with support for both Google Custom Search API and SerpAPI",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary\n- bump package version to 1.1.1 so publish workflow can ship the patch\n\n## Testing\n- npm version patch --no-git-tag-version